### PR TITLE
Fix Header DOM Shifts on Route Change

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -8,31 +8,22 @@ type ThemeSwitchType = {
 };
 
 export default function ThemeSwitch({ className }: ThemeSwitchType) {
-  const [isMounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!isMounted) return null;
 
   return (
     <>
-      {isMounted && (
-        <button
-          className={className}
-          onClick={() => {
-            setTheme(theme === 'light' ? 'dark' : 'light');
-          }}
-        >
-          {theme && theme === 'dark' ? (
-            <FaSun size={19} title="Get flash-banged" />
-          ) : (
-            <FaMoon size={19} title="Switch to gamer mode" />
-          )}
-        </button>
-      )}
+      <button
+        className={className}
+        onClick={() => {
+          setTheme(theme === 'light' ? 'dark' : 'light');
+        }}
+      >
+        {theme && theme === 'dark' ? (
+          <FaSun size={19} title="Get flash-banged" />
+        ) : (
+          <FaMoon size={19} title="Switch to gamer mode" />
+        )}
+      </button>
     </>
   );
 }

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -14,8 +14,6 @@ export default function Header() {
     setActive(!active);
   };
 
-  Router.events.on('routeChangeStart', () => setActive(false));
-
   return (
     <header className="sticky top-0 z-10 w-full bg-knut-light-bg text-knut-light-text dark:bg-knut-dark-bg dark:text-knut-dark-text">
       <link rel="apple-touch-icon" href="public/icons/knut3head-96x96.webp" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,7 +8,9 @@
   --background: #121212;
   --foreground: #121212;
 }
-
+body {
+  overflow-y: scroll;
+}
 h1 {
   font-size: 2rem;
 }


### PR DESCRIPTION
Fixed the Header shift on Route change.

There is no easy way of solving the flashbang in the current context because the pages are pre-rendered with the white theme so, on page load, the HTML version is shown then Next.js hydrates and takes over the HTML notices that the theme is set to dark, and changes it causing a white flash.

In my opinion, use Vanilla React with Vite since SEO isn't really important here because everyone will be going directly to the website from a link they see in the title and looking at the current robots.txt file all search engine crawlers are disallowed so the whole point of using Next.js is gone.

![Img](https://i.imgur.com/EkeQhwL.png)